### PR TITLE
Fixed the issue where pod has no condition

### DIFF
--- a/src/monitors/longnotready.js
+++ b/src/monitors/longnotready.js
@@ -20,6 +20,10 @@ class PodLongNotReady extends EventEmitter{
 		let pods = await kube.getPods();
 
 		for(let pod of pods){
+			if(!pod.status || !pod.status.conditions){
+				continue;
+			}
+
 			let readyStatus = pod.status.conditions.filter((item) => item.type === 'Ready');
 			
 			if(readyStatus.length === 0){


### PR DESCRIPTION
There is a case that some pods have no `.conditions` value. In my case, the pods were in phase `Failed` which requires manual reaping. (See https://github.com/kubernetes/kubernetes/issues/7660)