### PR TITLE
Monitoring in current namespace only

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Additionally, the following environment variables can be used:
 - `NOT_READY_MIN_TIME`: Time to wait after pod become not ready before notifying. (Default to 60000 or 60s)
 - `KUBE_USE_KUBECONFIG`: Read Kubernetes credentials from active context in ~/.kube/config (default off)
 - `KUBE_USE_CLUSTER`: Read Kubernetes credentials from pod (default on)
+- `KUBE_NAMESPACE_ONLY`: Monitor current namespace only instead of whole cluster (default false)
 
 ## License
 

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -1,6 +1,7 @@
 kube:
   inCluster: KUBE_USE_CLUSTER
   kubeconfig: KUBE_USE_KUBECONFIG
+  current_namespace_only: KUBE_NAMESPACE_ONLY
 
 interval: TICK_RATE
 flood_expire: FLOOD_EXPIRE

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -1,7 +1,8 @@
 kube:
   inCluster: KUBE_USE_CLUSTER
   kubeconfig: KUBE_USE_KUBECONFIG
-  current_namespace_only: KUBE_NAMESPACE_ONLY
+
+currentNamespaceOnly: KUBE_NAMESPACE_ONLY
 
 interval: TICK_RATE
 flood_expire: FLOOD_EXPIRE

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -12,7 +12,7 @@ kube:
   # namespace: 'default'
 
 # Monitor all namespaces
-current_namespace_only: false
+currentNamespaceOnly: false
 
 # polling interval
 interval: 15000

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -11,6 +11,9 @@ kube:
   version: 'v1'
   # namespace: 'default'
 
+# Monitor all namespaces
+current_namespace_only: false
+
 # polling interval
 interval: 15000
 flood_expire: 60000

--- a/src/kube.js
+++ b/src/kube.js
@@ -6,6 +6,7 @@ const bluebird = require('bluebird');
 class Kubernetes {
 	constructor(){
 		this.kube = new Api.Core(this.getConfig());
+		this.currentNamespaceOnly = config.get('current_namespace_only')
 	}
 
 	getConfig(){
@@ -30,7 +31,11 @@ class Kubernetes {
 
 	getPods(){
 		return bluebird.fromCallback((cb) => {
-			this.kube.pods.get(cb);
+			if(this.currentNamespaceOnly) {
+				this.kube.namespaces.pods.get(cb);
+			}else{
+				this.kube.pods.get(cb);
+			}
 		}).then((list) => {
 			return list.items;
 		});

--- a/src/kube.js
+++ b/src/kube.js
@@ -6,7 +6,7 @@ const bluebird = require('bluebird');
 class Kubernetes {
 	constructor(){
 		this.kube = new Api.Core(this.getConfig());
-		this.currentNamespaceOnly = config.get('current_namespace_only')
+		this.currentNamespaceOnly = config.get('currentNamespaceOnly')
 	}
 
 	getConfig(){


### PR DESCRIPTION
Added new option to force monitoring in current namespace only (or namespace selected in kubeconfig)