### PR TITLE
add PodCompleted to blacklistReason & minor fix

### DIFF
--- a/src/monitors/waitingpods.js
+++ b/src/monitors/waitingpods.js
@@ -5,7 +5,7 @@ const kube = require('../kube');
 class PodStatus extends EventEmitter{
 	constructor(){
 		super();
-		this.blacklistReason = ['ContainerCreating', 'PodInitializing'];
+		this.blacklistReason = ['ContainerCreating', 'PodInitializing', 'PodCompleted'];
 	}
 
 	start(){

--- a/src/notify/slack.js
+++ b/src/notify/slack.js
@@ -17,7 +17,7 @@ class SlackNotifier{
 		}
 
 		return this.slack.send({
-			text: item.text,
+			text: item.text || "Kubernetes Notification:",
 			attachments: [item],
 		}).then(() => {
 			console.log('Slack message sent');


### PR DESCRIPTION
This adds `PodCompleted` to the blacklistReason. Pods created by jobs get this as their status after successful completion.

Via this I found an edge case: If the text for a slack notification is undefined or empty, [`slack.send` returns `undefined`](https://github.com/xoxco/node-slack/blob/master/slack.js#L12-L15) (which is the case for Job pods). This results in some hard to trace errors. To avoid this case, I added a general default message, if none is given.

Thanks for considering this PR.