### PR TITLE
Check PodCompleted in longnotready instead of waitingpods

### DIFF
--- a/src/monitors/longnotready.js
+++ b/src/monitors/longnotready.js
@@ -35,6 +35,10 @@ class PodLongNotReady extends EventEmitter{
 			if(readyStatus.status === 'True'){
 				continue;
 			}
+			
+			if(readyStatus.reason === 'PodCompleted'){
+				continue;
+			}
 
 			let notReadySince = new Date(readyStatus.lastTransitionTime).getTime();
 			let notReadyDuration = new Date().getTime() - notReadySince;

--- a/src/monitors/waitingpods.js
+++ b/src/monitors/waitingpods.js
@@ -5,7 +5,7 @@ const kube = require('../kube');
 class PodStatus extends EventEmitter{
 	constructor(){
 		super();
-		this.blacklistReason = ['ContainerCreating', 'PodInitializing', 'PodCompleted'];
+		this.blacklistReason = ['ContainerCreating', 'PodInitializing'];
 	}
 
 	start(){


### PR DESCRIPTION
I mixed up the usage of `PodCompleted` in my previous PR #16. This fixes it.