### PR TITLE
Add possibility of ignoring specific pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ Additionally, the following environment variables can be used:
 - `KUBE_USE_CLUSTER`: Read Kubernetes credentials from pod (default on)
 - `KUBE_NAMESPACE_ONLY`: Monitor current namespace only instead of whole cluster (default false)
 
+In the case you want to ignore some specific deployments, you can mark the deployment with the following annotation:
+```
+annotations:
+  kube-slack/ignore-pod: "true"
+```
+This annotation will make `kube-slack` ignore any error on this particular pod.
+
 ## License
 
 [MIT License](LICENSE)

--- a/src/monitors/longnotready.js
+++ b/src/monitors/longnotready.js
@@ -20,6 +20,12 @@ class PodLongNotReady extends EventEmitter{
 		let pods = await kube.getPods();
 
 		for(let pod of pods){
+
+			// Ignore pod if the annotation is set and evaluates to true
+			if(pod.metadata.labels['kube-slack/ignore-pod']){
+				continue;
+			}
+
 			if(!pod.status || !pod.status.conditions){
 				continue;
 			}

--- a/src/monitors/waitingpods.js
+++ b/src/monitors/waitingpods.js
@@ -20,6 +20,12 @@ class PodStatus extends EventEmitter{
 		let containers = await kube.getContainerStatuses();
 
 		for(let item of containers){
+
+			// Ignore pod if the annotation is set and evaluates to true
+			if(item.pod.metadata.labels['kube-slack/ignore-pod']){
+				continue;
+			}
+
 			if(!item.state.waiting){
 				continue;
 			}


### PR DESCRIPTION
This commit fixes #18 by ignoring any pod that carries the following annotation:
```
kube-slack/ignore-pod: "true"
```
The PR also appends a paragraph to the `README.md` that explains how this annotation can be used.