### PR TITLE
Use `annotations` instead of `labels`

### DIFF
--- a/src/monitors/longnotready.js
+++ b/src/monitors/longnotready.js
@@ -22,7 +22,7 @@ class PodLongNotReady extends EventEmitter{
 		for(let pod of pods){
 
 			// Ignore pod if the annotation is set and evaluates to true
-			if(pod.metadata.labels['kube-slack/ignore-pod']){
+			if(pod.metadata.annotations['kube-slack/ignore-pod']){
 				continue;
 			}
 

--- a/src/monitors/waitingpods.js
+++ b/src/monitors/waitingpods.js
@@ -22,7 +22,7 @@ class PodStatus extends EventEmitter{
 		for(let item of containers){
 
 			// Ignore pod if the annotation is set and evaluates to true
-			if(item.pod.metadata.labels['kube-slack/ignore-pod']){
+			if(item.pod.metadata.annotations['kube-slack/ignore-pod']){
 				continue;
 			}
 


### PR DESCRIPTION
After merging PR #19 I realized that the commit used Kubernetes Labels and not Annotations (which was the original intention). This PR changes `labels` --> `annotations`.