### PR TITLE
Check if annotations is undefined

### DIFF
--- a/src/monitors/longnotready.js
+++ b/src/monitors/longnotready.js
@@ -22,7 +22,7 @@ class PodLongNotReady extends EventEmitter{
 		for(let pod of pods){
 
 			// Ignore pod if the annotation is set and evaluates to true
-			if(pod.metadata.annotations['kube-slack/ignore-pod']){
+			if(pod.metadata.annotations && pod.metadata.annotations['kube-slack/ignore-pod']){
 				continue;
 			}
 

--- a/src/monitors/waitingpods.js
+++ b/src/monitors/waitingpods.js
@@ -22,7 +22,7 @@ class PodStatus extends EventEmitter{
 		for(let item of containers){
 
 			// Ignore pod if the annotation is set and evaluates to true
-			if(item.pod.metadata.annotations['kube-slack/ignore-pod']){
+			if(pod.metadata.annotations && item.pod.metadata.annotations['kube-slack/ignore-pod']){
 				continue;
 			}
 


### PR DESCRIPTION
Before trying to access the `annotations` object, we should always if it's undefined (because the `annotations` map is optional in the Pod manifest). This commit adds a check that will short circuit
the if statement in case that `annotations` is evaluated to be falsey (e.g. `undefined`)

Fixes: #21