### PR TITLE
Optionally include Kubernetes cluster name in Slack notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Additionally, the following environment variables can be used:
 - `KUBE_USE_KUBECONFIG`: Read Kubernetes credentials from active context in ~/.kube/config (default off)
 - `KUBE_USE_CLUSTER`: Read Kubernetes credentials from pod (default on)
 - `KUBE_NAMESPACE_ONLY`: Monitor current namespace only instead of whole cluster (default false)
+- `CLUSTER_NAME`: Name of Kubernetes cluster to be included in the Slack notifications (default empty)
 
 ## Annotations
 

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -9,3 +9,5 @@ flood_expire: FLOOD_EXPIRE
 not_ready_min_time: NOT_READY_MIN_TIME
 
 slack_url: SLACK_URL
+
+cluster_name: CLUSTER_NAME

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -19,4 +19,6 @@ interval: 15000
 flood_expire: 60000
 not_ready_min_time: 60000
 
+cluster_name: ''
+
 # slack_url: 'https://wongnai.slack.com/services/hooks/incoming-webhooks?token=XXXX'

--- a/src/monitors/longnotready.js
+++ b/src/monitors/longnotready.js
@@ -6,6 +6,7 @@ class PodLongNotReady extends EventEmitter {
 	constructor() {
 		super();
 		this.minimumTime = config.get('not_ready_min_time');
+		this.clusterName = config.get('cluster_name');
 	}
 
 	start() {
@@ -71,14 +72,17 @@ class PodLongNotReady extends EventEmitter {
 				key = pod.metadata.ownerReferences[0].name;
 			}
 
+			const clusterInfo = this.clusterName ? ` in ${this.clusterName}` : '';
+			const podTitle = `${pod.metadata.namespace}/${
+				pod.metadata.name
+			}${clusterInfo}`;
+
 			this.emit('message', {
-				fallback: `Pod ${pod.metadata.namespace}/${
-					pod.metadata.name
-				} is not ready: ${readyStatus.reason} - ${readyStatus.message}`,
+				fallback: `Pod ${podTitle} is not ready: ${readyStatus.reason} - ${
+					readyStatus.message
+				}`,
 				color: 'danger',
-				title: `${pod.metadata.namespace}/${
-					pod.metadata.name
-				}: ${readyStatus.reason || 'Pod not ready'}`,
+				title: `${podTitle}: ${readyStatus.reason || 'Pod not ready'}`,
 				text: readyStatus.message || 'Pod not ready',
 				_key: key,
 				...messageProps,

--- a/src/monitors/waitingpods.js
+++ b/src/monitors/waitingpods.js
@@ -6,6 +6,7 @@ class PodStatus extends EventEmitter {
 	constructor() {
 		super();
 		this.blacklistReason = ['ContainerCreating', 'PodInitializing'];
+		this.clusterName = config.get('cluster_name');
 	}
 
 	start() {
@@ -49,16 +50,17 @@ class PodStatus extends EventEmitter {
 				key = item.pod.metadata.ownerReferences[0].name;
 			}
 
+			const clusterInfo = this.clusterName ? ` in ${this.clusterName}` : '';
+			const containerTitle = `${item.pod.metadata.namespace}/${
+				item.pod.metadata.name
+			}/${item.name}${clusterInfo}`;
+
 			this.emit('message', {
-				fallback: `Container ${item.pod.metadata.namespace}/${
-					item.pod.metadata.name
-				}/${item.name} entered status ${item.state.waiting.reason} (${
-					item.state.waiting.message
-				})`,
+				fallback: `Container ${containerTitle} entered status ${
+					item.state.waiting.reason
+				} (${item.state.waiting.message})`,
 				color: 'danger',
-				title: `${item.pod.metadata.namespace}/${item.pod.metadata.name}/${
-					item.name
-				}`,
+				title: containerTitle,
 				text: `Container entered status *${item.state.waiting.reason}*\n\`\`\`${
 					item.state.waiting.message
 				}\`\`\``,


### PR DESCRIPTION
These changes allows for cluster name to be configured with the `$CLUSTER_NAME` environment variable when starting the docker container.

This is valuable when running several Kubernetes clusters with the same containers / pods deployed, to immediately see which Kubernetes cluster the Slack notifications relates to.

Any thoughts?