### PR TITLE
Output structured logs with timestamp using bunyan

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.js",
   "dependencies": {
     "bluebird": "^3.4.1",
+    "bunyan": "1.8.12",
     "config": "^1.26.2",
     "js-yaml": "^3.9.1",
     "kubernetes-client": "^3.15.0",

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 const config = require('config');
 const FloodFilter = require('./floodFilter');
+const logger = require('./logger');
 
 class KubeMonitoring {
 	constructor() {
@@ -38,3 +39,5 @@ class KubeMonitoring {
 }
 
 new KubeMonitoring().start();
+
+logger.info('Kubernetes monitors started');

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,6 @@
+const bunyan = require('bunyan');
+
+module.exports = bunyan.createLogger({
+	name: 'kube-slack',
+	serializers: bunyan.stdSerializers,
+});

--- a/src/notify/slack.js
+++ b/src/notify/slack.js
@@ -1,12 +1,13 @@
 const config = require('config');
 const Slack = require('node-slack');
+const logger = require('../logger');
 
 class SlackNotifier {
 	constructor() {
 		try {
 			this.slack = new Slack(config.get('slack_url'));
-		} catch (e) {
-			console.error('Could not initialize Slack', e);
+		} catch (err) {
+			logger.error({ err }, 'Could not initialize Slack');
 			this.slack = null;
 		}
 	}
@@ -27,10 +28,10 @@ class SlackNotifier {
 			})
 			.then(
 				() => {
-					console.log('Slack message sent');
+					logger.info('Slack message sent');
 				},
-				e => {
-					console.error(e);
+				err => {
+					logger.error({ err }, 'Could not send notification to Slack');
 				}
 			);
 	}


### PR DESCRIPTION
Structured logs with timestamp included is incredibly valuable when trying to debug any issues or just want to double check if everything is still running as expected.

bunyan is a proven logger that outputs JSON to stdout.

Example of running this locally:

```bash
$ KUBE_USE_KUBECONFIG=true KUBE_USE_CLUSTER=false SLACK_URL=https://example.com node .
{"name":"kube-slack","hostname":"phillipjs-dev-machine","pid":32760,"level":30,"msg":"Kubernetes monitors started","time":"2018-05-04T13:41:08.368Z","v":0}
```

Lots of ways to alter the bunyan output while running locally or searching through the logs when it runs in the Kubernetes cluster with the [bunyan CLI](https://github.com/trentm/node-bunyan#cli-usage).

Would you consider this useful in this project?

Refs https://github.com/trentm/node-bunyan