### PR TITLE
fix broken namespace only functionality

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,5 @@
 node_modules
 Dockerfile
 config/local*.yaml
+test.env
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 package-lock.json
 yarn.lock
 config/local*.yaml
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.5.0] - 2018-08-21
+### Added
+- `KUBE_NAMESPACES_ONLY` option (#40). Ability add watch multiple explicit namespaces.
+- Start watching right after start of the app instead of waiting for initial interval to expire.
+- Added prettier script to package.json and devDependency
+
+### Removed
+- `KUBE_NAMESPACE_ONLY` support (was broken since 3.4.0 anyways. Now superseded by `KUBE_NAMESPACES_ONLY`)
+
 ## [3.4.0] - 2018-06-15
 ### Added
 - `SLACK_CHANNEL` option (#36)

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Additionally, the following environment variables can be used:
 - `NOT_READY_MIN_TIME`: Time to wait after pod become not ready before notifying. (Default to 60000 or 60s)
 - `KUBE_USE_KUBECONFIG`: Read Kubernetes credentials from active context in ~/.kube/config (default off)
 - `KUBE_USE_CLUSTER`: Read Kubernetes credentials from pod (default on)
-- `KUBE_NAMESPACE_ONLY`: Monitor current namespace only instead of whole cluster (default false)
+- `KUBE_NAMESPACES_ONLY`: Monitor a list of specific namespaces, specified either as json array or as a string of comma seperated values (`foo_namespace,bar_namespace`).
 - `SLACK_CHANNEL`: Override channel to send
 - `SLACK_PROXY`: URL of HTTP proxy used to connect to Slack
 

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -2,7 +2,7 @@ kube:
   inCluster: KUBE_USE_CLUSTER
   kubeconfig: KUBE_USE_KUBECONFIG
 
-currentNamespaceOnly: KUBE_NAMESPACE_ONLY
+namespaces_only: KUBE_NAMESPACES_ONLY
 
 interval: TICK_RATE
 flood_expire: FLOOD_EXPIRE

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -11,8 +11,8 @@ kube:
   version: 'v1'
   # namespace: 'default'
 
-# Monitor all namespaces
-currentNamespaceOnly: false
+# if set, this must be an array / list of namespaces to watch
+namespaces_only:
 
 # polling interval
 interval: 15000

--- a/package.json
+++ b/package.json
@@ -1,13 +1,20 @@
 {
   "name": "kube-slack",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "",
   "main": "src/index.js",
+  "scripts": {
+    "prettier": "prettier \"src/**/*.js\" --write"
+  },
   "dependencies": {
     "bunyan": "^1.8.12",
     "config": "^1.30.0",
+    "core-js": "^3.0.0-beta.3",
     "js-yaml": "^3.11.0",
     "kubernetes-client": "^5.3.0",
     "node-slack": "0.0.7"
+  },
+  "devDependencies": {
+    "prettier": "^1.14.2"
   }
 }

--- a/src/kube.js
+++ b/src/kube.js
@@ -1,11 +1,29 @@
 const fs = require('fs');
 const config = require('config');
 const Api = require('kubernetes-client');
+const assert = require('assert');
+const logger = require('./logger');
+require('core-js/features/array/flat');
 
 class Kubernetes {
 	constructor() {
 		this.kube = new Api.Core(this.getConfig());
-		this.currentNamespaceOnly = config.get('currentNamespaceOnly');
+		let namespaces_only = config.get('namespaces_only');
+		if (namespaces_only) {
+			if (!Array.isArray(namespaces_only)) {
+				namespaces_only = namespaces_only
+					.split(',')
+					.map(namespace => namespace.trim());
+			}
+			logger.info(
+				`Watching pods the following namespaces: ${namespaces_only.join(',')} .`
+			);
+		} else {
+			logger.info(
+				`KUBE_NAMESPACE_ONLY not set. Watching pods in ALL namespaces.`
+			);
+		}
+		this.namespaces_only = namespaces_only;
 	}
 
 	getConfig() {
@@ -28,15 +46,45 @@ class Kubernetes {
 		return cfg;
 	}
 
-	getPods() {
-		const promise = this.currentNamespaceOnly
-			? this.kube.namespaces.pods.get()
-			: this.kube.pods.get();
-		return promise.then(list => list.items);
+	async getAllPodsInCluster() {
+		return this.kube.pods.get().then(list => list.items);
+	}
+
+	async getPodsInNamespace(namespace) {
+		try {
+			const podsListResult = await this.kube.namespaces(namespace).pods.get();
+			return podsListResult.items;
+		} catch (e) {
+			logger.info(
+				e,
+				`Error while attempting to retrieve pods in namespace: ${namespace}. Does the namespace exist and did you set the correct permissions?`
+			);
+
+			throw e;
+		}
+	}
+
+	async getPodsInWatchedNamespaces() {
+		// arrOfArrOfPods: Array<Error|Array<Pod>>
+		const arrOfArrOfPods = await Promise.all(
+			this.namespaces_only.map(
+				namespace => this.getPodsInNamespace(namespace).catch(e => e) // catch errors and simply return the Error object - we don't want the whole watch cycle to stop just because one of the namespaces couldn't watched.
+			)
+		);
+
+		return arrOfArrOfPods
+			.filter(podArrOrError => !(podArrOrError instanceof Error)) // filter out error from namespaces which failed get watched, the error has been already logged. TODO: notify on slack when a namespace could not be watched successfully.
+			.flat();
+	}
+
+	getWatchedPods() {
+		return this.namespaces_only
+			? this.getPodsInWatchedNamespaces()
+			: this.getAllPodsInCluster();
 	}
 
 	async getContainerStatuses() {
-		let pods = await this.getPods();
+		let pods = await this.getWatchedPods();
 		let out = [];
 		for (let item of pods) {
 			if (!item.status.containerStatuses) {

--- a/src/monitors/index.js
+++ b/src/monitors/index.js
@@ -1,4 +1,1 @@
-module.exports = [
-	require('./waitingpods'),
-	require('./longnotready'),
-];
+module.exports = [require('./waitingpods'), require('./longnotready')];

--- a/src/monitors/longnotready.js
+++ b/src/monitors/longnotready.js
@@ -13,11 +13,14 @@ class PodLongNotReady extends EventEmitter {
 			this.check();
 		}, config.get('interval'));
 
+		// run an initial check right after the start instead of waiting for first interval to kick in.
+		this.check();
+
 		return this;
 	}
 
 	async check() {
-		let pods = await kube.getPods();
+		let pods = await kube.getWatchedPods();
 
 		for (let pod of pods) {
 			let messageProps = {};

--- a/src/notify/index.js
+++ b/src/notify/index.js
@@ -1,3 +1,1 @@
-module.exports = [
-	require('./slack'),
-];
+module.exports = [require('./slack')];


### PR DESCRIPTION
With kube-slack 3.4.0 when setting `KUBE_NAMESPACE_ONLY=true` the app crashes with
```
(node:1) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'get' of undefined
    at Kubernetes.getPods (/app/src/kube.js:33:32)
    at Kubernetes.getContainerStatuses (/app/src/kube.js:39:25)
    at PodStatus.check (/app/src/monitors/waitingpods.js:20:31)
    at Timeout.setInterval [as _onTimeout] (/app/src/monitors/waitingpods.js:13:9)
    at ontimeout (timers.js:427:11)
    at tryOnTimeout (timers.js:289:5)
    at listOnTimeout (timers.js:252:5)
    at Timer.processTimers (timers.js:212:10)
(node:1) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
```

This bug must've been introduced with the kubernetes-client dependency update in kube-slack v3.4.0, because kubernetes-client removed the default functionality in https://github.com/godaddy/kubernetes-client/pull/190 .

This PR fixes kube-slack by removing this particular flag and introducing a more powerful namespaces_only flag to watch multiple namespaces. It is implemented by just using the namespaced pod list functionality, so that kube-slack doesn't necessarily require a clusterrole to list only one or few specific namespaces, but only needs access to the watched namespaces instead.