### PR TITLE
Update deployment template example image to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ spec:
      # serviceAccountName: kube-slack
       containers:
       - name: kube-slack
-        image: willwill/kube-slack:v3.4.0
+        image: willwill/kube-slack:v3.6.0
         env:
         - name: SLACK_URL
           value: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX


### PR DESCRIPTION
This PR updates deployment template in README to use kubeslack latest image version.