### PR TITLE
IGNORE_PODS

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Additionally, the following environment variables can be used:
 - `TICK_RATE`: How often to update in milliseconds. (Default to 15000 or 15s)
 - `FLOOD_EXPIRE`: Repeat notification after this many milliseconds has passed after status returned to normal. (Default to 60000 or 60s)
 - `NOT_READY_MIN_TIME`: Time to wait after pod become not ready before notifying. (Default to 60000 or 60s)
+- `IGNORE_PODS`: Comma separated list with the name prefix of the pods to ignore. Example: `kube-proxy-gke,prometheus-prometheus-node-exporter`  (Default "")
 - `METRICS_CPU`: Enable/disable metric alerting on cpu (Default true)
 - `METRICS_MEMORY`: Enable/disable metric alerting on memory (Default true)
 - `METRICS_PERCENT`: Set percentage threshold on metric alerts (Default 80)

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -24,6 +24,7 @@ metrics_requests:
   __format: json
 flood_expire: FLOOD_EXPIRE
 not_ready_min_time: NOT_READY_MIN_TIME
+ignore_pods: IGNORE_PODS
 
 slack_url: SLACK_URL
 slack_channel: SLACK_CHANNEL

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -21,6 +21,8 @@ interval: 15000
 flood_expire: 60000
 not_ready_min_time: 60000
 
+ignore_pods: ""
+
 metrics_cpu: true
 metrics_memory: true
 metrics_alert: 80 # percent


### PR DESCRIPTION
**Motivation**

Due to work of cluster autoscaler, I get a lot of errors like:
```
Pod not ready
  kube-system/kube-proxy-gke-core-private-test-env-f2a4354b-23mh: Pod not ready
  Pod not ready

Pod not ready
  monitoring/prometheus-prometheus-node-exporter-2pf54: Pod not ready
  Pod not ready
```
So with using `ignore_pods` env such alerts will be ignored.

Sample value: `kube-proxy-gke-corem,prometheus-prometheus-node-exporter`

Workaround for:
https://github.com/wongnai/kube-slack/issues/33

Possible will fix:
https://github.com/wongnai/kube-slack/issues/29