### PR TITLE
Avoid error when slack_username is not defined

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -28,5 +28,5 @@ metrics_requests: false # Alert if pods are above requests resources (no limits 
 
 # slack_url: 'https://wongnai.slack.com/services/hooks/incoming-webhooks?token=XXXX'
 slack_channel: null
-# slack_username: null
+slack_username: 'kube-slack'
 # slack_proxy: null


### PR DESCRIPTION
    When the envrionent variable slack_username is not defined it throws this error:

    (node:1) UnhandledPromiseRejectionWarning: Error: Configuration property "slack_username" is not defined
        at Config.get (/app/node_modules/config/lib/config.js:182:11)
        at SlackNotifier.notify (/app/notify/slack.js:26:48)
        at PodLongNotReady.callback (/app/index.js:27:26)
        at PodLongNotReady.emit (events.js:198:13)
        at PodLongNotReady.check (/app/monitors/longnotready.js:65:18)
        at process._tickCallback (internal/process/next_tick.js:68:7)
    (node:1) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)

    With this commit we avoid this error if this environment variable is not defined