### PR TITLE
Fixed missing metrics permissions in SA

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kube-slack
 rules:
-- apiGroups: [""]
+- apiGroups: ["metrics.k8s.io"]
   resources: ["pods"]
   verbs: ["get", "watch", "list"]
 ---


### PR DESCRIPTION
I realized there was a missing permission bug in the README example when the pod tries to fetch pod metrics